### PR TITLE
Force python2, for building on Ubuntu 20.04+

### DIFF
--- a/xml2po.py
+++ b/xml2po.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import sys
 import os
 import string


### PR DESCRIPTION
By default Ubuntu 20,.04 has python2 and python3 in /usr/bin, but no python.

See also: https://github.com/oe-alliance/YahooWeather/pull/1